### PR TITLE
Added simple fix to prevent exception throw when canceling selection

### DIFF
--- a/src/nl/ou/refd/plugin/ui/topbarmenu/CombineMethodsIntoClassButton.java
+++ b/src/nl/ou/refd/plugin/ui/topbarmenu/CombineMethodsIntoClassButton.java
@@ -61,6 +61,8 @@ public class CombineMethodsIntoClassButton extends MenuButtonHandler {
 		destinationSelector.open();
 		
 		Object[] result = destinationSelector.getResult();
+		if (result == null) return; // the user pressed cancel on the selection dialog
+		// TODO: properly handle this with warnings, also handle the case where user presses OK on empty selection.
 		
 		List<MethodSpecification> targets = Arrays.asList(Arrays.copyOf(result, result.length, MethodSpecification[].class));
 		


### PR DESCRIPTION
Method handle() now returns when user cancels, preventing an exception and stack dump. Nothing happens and the cancel action has been handled. This fixes #11. Future work should handle the cancel event properly in the UI (instead of checking for null).